### PR TITLE
ci: fix latent hadolint failure in Deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,20 +44,9 @@ jobs:
           echo "Workflow dispatch reason: $INPUTS_REASON"
           echo "Use test image: $INPUTS_USE_TEST_IMAGE"
 
-  hadolint:
-    name: Run hadolint against docker files
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Pull hadolint/hadolint:latest Image
-        run: docker pull hadolint/hadolint:latest
-      - name: Run hadolint against Dockerfiles
-        run: docker run --rm -i -v "$PWD":/workdir --workdir /workdir --entrypoint hadolint hadolint/hadolint --ignore DL3015 --ignore DL3003 --ignore DL3006 --ignore DL3010 --ignore DL4001 --ignore DL3007 --ignore DL3008 --ignore SC2068 --ignore DL3007 --ignore SC1091 --ignore DL3013 --ignore DL3010 --ignore SC3054 $(find . -type f -iname "Dockerfile*")
-
   build_and_push:
     name: Image Build & Push
     uses: sdr-enthusiasts/common-github-workflows/.github/workflows/sdre.yml@d99ce7f631ca56901a4aecca25d5c6e4b0a7e2f1 # main
-    # needs: [hadolint]
     with:
       push_enabled: true
       push_destinations: ghcr.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,4 +49,4 @@ COPY rootfs/ /
 VOLUME ["/data"]
 
 HEALTHCHECK --interval=60s --timeout=10s --start-period=30s --retries=3 \
-    CMD /scripts/healthcheck.sh
+    CMD ["/scripts/healthcheck.sh"]


### PR DESCRIPTION
## Problem

Latent rather than currently visible. The last `Deploy` runs were on 2026-07-14 and both succeeded:

```text
2026-07-14T17:11  Deploy  success
2026-07-14T15:48  Deploy  success
2026-06-26T22:05  Deploy  success
```

hadolint **v2.15.0** was published on 2026-07-30T13:39:01Z, after that. Because the `hadolint` job pulled unpinned `hadolint/hadolint:latest`, the next `Deploy` — the next time `docker-baseimage` fans out — would have gone red with nothing in this repo having changed. Replaying the job's exact command against current `:latest` (2.15.1) on the unfixed Dockerfile:

```console
$ docker run --rm -i -v "$PWD":/workdir --workdir /workdir --entrypoint hadolint hadolint/hadolint \
    --ignore DL3015 --ignore DL3003 --ignore DL3006 --ignore DL3010 --ignore DL4001 \
    --ignore DL3007 --ignore DL3008 --ignore SC2068 --ignore DL3007 --ignore SC1091 \
    --ignore DL3013 --ignore DL3010 --ignore SC3054 $(find . -type f -iname "Dockerfile*")
./Dockerfile:51 DL3025 warning: Use arguments JSON notation for CMD and ENTRYPOINT arguments
rc=1
```

Unlike `docker-adsbhub` and `docker-planefinder`, `build_and_push` did **not** gate on this job — `needs: [hadolint]` was already commented out — so the image would still have shipped. The job would only have painted the run red.

## Root cause

hadolint [#1209](https://github.com/hadolint/hadolint/pull/1209) extended `DL3025` to fire on `HEALTHCHECK ... CMD` as well as `CMD`/`ENTRYPOINT`, shipping in v2.15.0. `DL3025` itself is not new; only the `HEALTHCHECK` coverage is.

```console
$ hadolint Dockerfile     # 2.14.0, the flake.lock pin
rc=0

$ docker run --rm -i --entrypoint hadolint hadolint/hadolint:latest --no-color - < Dockerfile
-:51 DL3025 warning: Use arguments JSON notation for CMD and ENTRYPOINT arguments
rc=1
```

## Changes

**`fix: use JSON exec form for HEALTHCHECK CMD`** — the actual violation. Note the instruction spans two lines with `CMD` on the continuation, so hadolint reports line 51 while the edit lands on line 52. The multi-line form is preserved; only the argument notation changes:

```diff
 HEALTHCHECK --interval=60s --timeout=10s --start-period=30s --retries=3 \
-    CMD /scripts/healthcheck.sh
+    CMD ["/scripts/healthcheck.sh"]
```

**`ci: drop redundant hadolint job from deploy workflow`** — removes the job and the dead commented `# needs: [hadolint]` reference.

```console
$ yq '.jobs | keys' .github/workflows/deploy.yml
- workflow-dispatch
- build_and_push
```

Coverage is unchanged. This repo already had `check_docker = true`, so `lint.yaml` was already linting the Dockerfile via pre-commit. Verified rather than assumed:

```console
$ grep -o '"id": "hadolint"' .pre-commit-config.yaml
"id": "hadolint"
$ grep -o '/nix/store/[^"]*hadolint-[0-9.]*/bin/hadolint' .pre-commit-config.yaml
/nix/store/gg0zllfabq395d8i6vyn3ljbavfh4d1p-hadolint-2.14.0/bin/hadolint
```

The removed ignore list included `--ignore SC3054`, deliberately **not** carried over. SC3054 is spuriously triggered by a hadolint 2.15.x shell-tracking regression — an `ARG`/`ENV` between `SHELL` and a `RUN` resets the dialect back to POSIX sh:

```dockerfile
FROM debian:trixie-slim
SHELL ["/bin/bash", "-o", "pipefail", "-c"]
ARG FOO="bar"
RUN P=() && P+=(nginx) && echo "${P[@]}"
```

```text
2.15.1 -> SC3054 warning: In POSIX sh, array references are undefined.   rc=1
2.14.0 -> rc=0
```

This Dockerfile does not trip it (its `ENV` precedes `SHELL`), and suppressing SC3054 fleet-wide would mask real POSIX-compatibility findings.

## Verification

The exec form drops the intervening `/bin/sh -c`, so the kernel must resolve the script's `#!/command/with-contenv bash` shebang itself — a symlink into the s6-overlay tree, not a normal interpreter path. Preconditions hold in the published image:

```console
$ docker run --rm --entrypoint /bin/sh ghcr.io/sdr-enthusiasts/docker-radarvirtuel:latest \
    -c 'ls -l /command/with-contenv; ls -l /scripts/healthcheck.sh; head -1 /scripts/healthcheck.sh'
lrwxrwxrwx 1 root root 48 /command/with-contenv -> ../package/admin/s6-overlay/command/with-contenv
-rwxr-xr-x 1 root root 1549 /scripts/healthcheck.sh
#!/command/with-contenv bash
```

Both forms side by side under Docker's real healthcheck machinery — the **published image** (shell form) against a **local build of this branch** (exec form), with only the probe timing overridden so it fires in reasonable time:

```text
=== published / shell ===                    === rebuilt / exec ===
healthy                                      healthy
["CMD-SHELL","/scripts/healthcheck.sh"]      ["CMD","/scripts/healthcheck.sh"]
exit=0 out="Status not yet available\n"      exit=0 out="Status not yet available\n"
```

Identical status, exit code and output. `Config.Entrypoint` is `["/init"]` on both, so s6 remains PID 1 and `docker stop` still reaches it for graceful shutdown.

Because this probe *passes*, the failure direction was checked separately on this same image to be sure exec form does not swallow a non-zero exit:

```console
$ # FROM <this branch's build> with HEALTHCHECK CMD ["/bin/false"]
exec-form non-zero exit -> status=unhealthy  test=["CMD","/bin/false"]
  exit=1
```

Image config compared against the published image — only `Test[0]` differs, and all four flags survive:

```console
built    : {"Test":["CMD","/scripts/healthcheck.sh"],"Interval":60000000000,"Timeout":10000000000,"StartPeriod":30000000000,"Retries":3}
published: {"Test":["CMD-SHELL","/scripts/healthcheck.sh"],"Interval":60000000000,"Timeout":10000000000,"StartPeriod":30000000000,"Retries":3}
```

Checked at **each commit individually**, not just at the tip, so `git bisect` stays usable — including the coverage invariant, which must hold at every commit:

```text
SHA       2.14.0  2.15.1  pc-hadolint  legacy-job  subject
54b2490f  rc=0    rc=0    true         1           fix: use JSON exec form for HEALTHCHECK CMD
89a625c4  rc=0    rc=0    true         0           ci: drop redundant hadolint job from deploy workflow
```

Every row satisfies `pc-hadolint=true OR legacy-job=1`, so Dockerfile linting is continuous across the series.

Also checked:

- `nix develop -c pre-commit run --all-files`: green, all hooks Passed or Skipped, including `hadolint`, `shellcheck-bash`, `check-github-workflows` and `check-yaml`
- `docker build --platform linux/amd64`: succeeds
- hadolint accepts the multi-line JSON form as a `HEALTHCHECK` (not as a bare `CMD`): `rc=0`
- No hooks bypassed; no `--no-verify`
